### PR TITLE
Potential fix for code scanning alert no. 1: Unread local variable

### DIFF
--- a/src/test/java/org/emilholmegaard/owaspscanner/scanners/dotnet/XssPreventionRuleTest.java
+++ b/src/test/java/org/emilholmegaard/owaspscanner/scanners/dotnet/XssPreventionRuleTest.java
@@ -106,7 +106,6 @@ public class XssPreventionRuleTest extends AbstractRuleTest {
         when(context.getFilePath()).thenReturn(Paths.get("JavaScriptFile.js"));
         
         // Get the line indices to simulate the correct context
-        int scriptBlockStart = 1; // The index of the "<script>" line
         when(context.getFileContent()).thenReturn(fileContent);
         
         // Setup the context with the right surrounding lines


### PR DESCRIPTION
Potential fix for [https://github.com/emilholmegaard/owasp-scanner/security/code-scanning/1](https://github.com/emilholmegaard/owasp-scanner/security/code-scanning/1)

To fix the problem, we need to remove the unused variable `scriptBlockStart` from the method `shouldDetectXssInJavaScript`. This will clean up the code and ensure that there are no unused variables, making the code easier to understand and maintain.

- Locate the line where `scriptBlockStart` is declared and assigned a value.
- Remove this line from the method.
- Ensure that the removal does not affect any other part of the code, as the variable is not used elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
