### PR TITLE
Make rule instances singletons to improve rule factory efficiency

### DIFF
--- a/src/main/java/org/emilholmegaard/owaspscanner/scanners/dotnet/DotNetRuleFactory.java
+++ b/src/main/java/org/emilholmegaard/owaspscanner/scanners/dotnet/DotNetRuleFactory.java
@@ -7,11 +7,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Factory class for creating and managing DotNet security rules.
  * Uses the factory pattern to instantiate appropriate rule objects.
  * Implements a HashMap-based approach for cleaner rule management.
+ * Caches rule instances as singletons to improve performance.
  */
 public class DotNetRuleFactory {
     
@@ -21,12 +23,17 @@ public class DotNetRuleFactory {
     // Map of rule ID to rule supplier for lazy instantiation
     private final Map<String, Supplier<SecurityRule>> ruleSuppliers;
     
+    // Cache for rule instances to ensure singleton behavior for each rule
+    private final Map<String, SecurityRule> ruleCache;
+    
     /**
      * Private constructor to enforce singleton pattern.
-     * Initializes the rule suppliers map.
+     * Initializes the rule suppliers map and rule cache.
      */
     private DotNetRuleFactory() {
         ruleSuppliers = new HashMap<>();
+        // Using ConcurrentHashMap for thread safety
+        ruleCache = new ConcurrentHashMap<>();
         registerRules();
     }
     
@@ -59,15 +66,18 @@ public class DotNetRuleFactory {
     
     /**
      * Creates all available DotNet security rules.
+     * Uses the rule cache to ensure each rule is a singleton.
      *
      * @return List of security rules for DotNet
      */
     public List<SecurityRule> createAllRules() {
         List<SecurityRule> rules = new ArrayList<>();
         
-        // Create each rule using its supplier
-        for (Supplier<SecurityRule> supplier : ruleSuppliers.values()) {
-            rules.add(supplier.get());
+        // Get or create each rule instance
+        for (Map.Entry<String, Supplier<SecurityRule>> entry : ruleSuppliers.entrySet()) {
+            String ruleId = entry.getKey();
+            SecurityRule rule = getRuleFromCache(ruleId);
+            rules.add(rule);
         }
         
         return rules;
@@ -75,13 +85,30 @@ public class DotNetRuleFactory {
     
     /**
      * Creates a specific rule by ID.
+     * Uses the rule cache to ensure each rule is a singleton.
      *
      * @param ruleId The ID of the rule to create
      * @return The requested security rule, or null if not found
      */
     public SecurityRule createRule(String ruleId) {
-        Supplier<SecurityRule> supplier = ruleSuppliers.get(ruleId);
-        return (supplier != null) ? supplier.get() : null;
+        if (!ruleSuppliers.containsKey(ruleId)) {
+            return null;
+        }
+        return getRuleFromCache(ruleId);
+    }
+    
+    /**
+     * Gets a rule from the cache or creates it if it doesn't exist.
+     *
+     * @param ruleId The ID of the rule to get or create
+     * @return The cached or newly created rule instance
+     */
+    private SecurityRule getRuleFromCache(String ruleId) {
+        // Using computeIfAbsent for thread-safe lazy initialization
+        return ruleCache.computeIfAbsent(ruleId, id -> {
+            Supplier<SecurityRule> supplier = ruleSuppliers.get(id);
+            return supplier.get();
+        });
     }
     
     /**
@@ -92,5 +119,15 @@ public class DotNetRuleFactory {
      */
     public void registerRule(String ruleId, Supplier<SecurityRule> supplier) {
         ruleSuppliers.put(ruleId, supplier);
+        // Remove from cache if it exists to ensure new supplier is used next time
+        ruleCache.remove(ruleId);
+    }
+    
+    /**
+     * Clears the rule cache.
+     * This can be useful in testing or when rules need to be recreated.
+     */
+    public void clearCache() {
+        ruleCache.clear();
     }
 }


### PR DESCRIPTION
## Description
This PR implements issue #9 by adding rule caching in the DotNetRuleFactory to make rule instances behave like singletons.

## Changes Made
- Added a thread-safe rule cache using `ConcurrentHashMap` to the DotNetRuleFactory
- Modified the `createAllRules()` and `createRule()` methods to use the cache
- Added a `getRuleFromCache()` helper method to centralize the caching logic
- Added a `clearCache()` method for testing or when rules need to be recreated
- Updated documentation to reflect the changes

## Implementation Notes
- Used `ConcurrentHashMap` to ensure thread safety
- Used `computeIfAbsent` for thread-safe lazy initialization of rule instances
- Added a cache clearing mechanism when registering new rule suppliers

## Testing
This change should be tested for:
1. Improved performance and reduced memory usage
2. Consistent behavior with the original implementation
3. Thread safety under concurrent access

## Closes
Closes #9